### PR TITLE
Support display names

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ var mailer = new SmtpMailer({
 });
 mailer.send({
 	subject: 'Subject',
-	from: { address: 'mail@example.com', displayName: 'It\s me, Mario!' },
+	from: { address: 'mail@example.com', displayName: "It's me, Mario!" },
 	to: ['mail@example.com'],
 	content: {
 		text: 'hello',

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # smtpmailer
 
-Runs on sys targets and nodejs. 
+Runs on sys targets and nodejs.
 
 #### SSL/StartTls:
 - Supported on java/php/nodejs
-- Supported on haxe 3.2 neko/cpp with `-lib hxssl` 
+- Supported on haxe 3.2 neko/cpp with `-lib hxssl`
 - Supported on haxe 3.3+ neko/cpp (using native sys.ssl.Socket)
 
 ```haxe
@@ -18,7 +18,7 @@ var mailer = new SmtpMailer({
 });
 mailer.send({
 	subject: 'Subject',
-	from: 'mail@example.com',
+	from: { address: 'mail@example.com', displayName: 'It\s me, Mario!' },
 	to: ['mail@example.com'],
 	content: {
 		text: 'hello',

--- a/src/smtpmailer/Address.hx
+++ b/src/smtpmailer/Address.hx
@@ -16,4 +16,9 @@ abstract Address(AddressData) from AddressData {
 	@:from
 	public static function ofString( address: String ): Address
 		return new Address({ address: address });
+
+	public function format()
+		return this.displayName != null
+			? '"${this.displayName}" ${this.address}'
+			: '${this.address}';
 }

--- a/src/smtpmailer/Address.hx
+++ b/src/smtpmailer/Address.hx
@@ -1,0 +1,21 @@
+package smtpmailer;
+
+using smtpmailer.AddressTools;
+
+typedef AddressData = {
+	address: String,
+	?displayName: String,
+}
+
+@:forward()
+abstract Address(AddressData) from AddressData {
+	public inline function new( address: AddressData )
+		this = {
+			address: AddressTools.sanitizeAddress(address.address),
+			displayName: address.displayName
+		}
+
+	@:from
+	public static function ofString( address: String ): Address
+		return new Address({ address: address });
+}

--- a/src/smtpmailer/Address.hx
+++ b/src/smtpmailer/Address.hx
@@ -1,13 +1,11 @@
 package smtpmailer;
 
-using smtpmailer.AddressTools;
-
 typedef AddressData = {
 	address: String,
 	?displayName: String,
 }
 
-@:forward()
+@:forward
 abstract Address(AddressData) from AddressData {
 	public inline function new( address: AddressData )
 		this = {

--- a/src/smtpmailer/AddressTools.hx
+++ b/src/smtpmailer/AddressTools.hx
@@ -1,0 +1,8 @@
+package smtpmailer;
+
+class AddressTools {
+    public static function sanitizeAddress( address: String )
+        return address.indexOf('<') > -1
+            ? address
+            : '<$address>';
+}

--- a/src/smtpmailer/Email.hx
+++ b/src/smtpmailer/Email.hx
@@ -1,8 +1,8 @@
 package smtpmailer;
 
 typedef Email = {
-	from: String,
-	to: Array<String>,
+	from: Address,
+	to: Array<Address>,
 	subject: String,
 	?headers: Map<String, String>,
 	content: {

--- a/src/smtpmailer/MultipartEncoder.hx
+++ b/src/smtpmailer/MultipartEncoder.hx
@@ -33,8 +33,14 @@ class MultipartEncoder {
 			main = content;
 		}
 
-		main.setHeader('From', '"${email.from.displayName}" <${email.from.address}>');
-		main.setHeader('To', email.to.map(function(to) return '"${to.displayName}" <${to.address}>').join(','));
+		main.setHeader('From', email.from.displayName != null
+			? '"${email.from.displayName}" ${email.from.address}'
+			: '${email.from.address}'
+		);
+		main.setHeader('To', email.to.map(function(to) return to.displayName != null
+			? '"${to.displayName}" ${to.address}'
+			: '${to.address}'
+		).join(','));
 		main.setHeader('Subject', email.subject);
 		if (email.headers != null)
 			for (key in email.headers.keys())

--- a/src/smtpmailer/MultipartEncoder.hx
+++ b/src/smtpmailer/MultipartEncoder.hx
@@ -8,7 +8,7 @@ class MultipartEncoder {
 	public static function encode(email: Email): String {
 		var main: Part;
 		var content: Part;
-		
+
 		if (email.content.html == null) {
 			content = new Part('text/plain', 'utf-8');
 			content.setContent(email.content.text);
@@ -19,7 +19,7 @@ class MultipartEncoder {
 			if (email.content.html != null)
 				content.newPart('text/html').setContent(email.content.html);
 		}
-			
+
 		if (email.attachments != null) {
 			main = new Part('multipart/mixed');
 			main.addPart(content);
@@ -32,15 +32,15 @@ class MultipartEncoder {
 		} else {
 			main = content;
 		}
-		
-		main.setHeader('From', email.from);
-		main.setHeader('To', email.to.join(','));
+
+		main.setHeader('From', '"${email.from.displayName}" <${email.from.address}>');
+		main.setHeader('To', email.to.map(function(to) return '"${to.displayName}" <${to.address}>').join(','));
 		main.setHeader('Subject', email.subject);
 		if (email.headers != null)
 			for (key in email.headers.keys())
 				main.setHeader(key, email.headers.get(key));
-		
+
 		return main.get();
 	}
-	
+
 }

--- a/src/smtpmailer/MultipartEncoder.hx
+++ b/src/smtpmailer/MultipartEncoder.hx
@@ -33,14 +33,8 @@ class MultipartEncoder {
 			main = content;
 		}
 
-		main.setHeader('From', email.from.displayName != null
-			? '"${email.from.displayName}" ${email.from.address}'
-			: '${email.from.address}'
-		);
-		main.setHeader('To', email.to.map(function(to) return to.displayName != null
-			? '"${to.displayName}" ${to.address}'
-			: '${to.address}'
-		).join(','));
+		main.setHeader('From', email.from.format());
+		main.setHeader('To', email.to.map(function(to) return to.format()).join(','));
 		main.setHeader('Subject', email.subject);
 		if (email.headers != null)
 			for (key in email.headers.keys())

--- a/src/smtpmailer/SmtpMailer.hx
+++ b/src/smtpmailer/SmtpMailer.hx
@@ -84,10 +84,10 @@ class SmtpMailer {
 		var encoded: String = MultipartEncoder.encode(email);
 		try {
 			@await connect();
-			@await writeLine('MAIL from: ${AddressTools.sanitizeAddress(email.from.address)}');
+			@await writeLine('MAIL from: ${email.from.address}');
 			@await readLine(250);
 			for (user in email.to) {
-				@await writeLine('RCPT to: ${AddressTools.sanitizeAddress(user.address)}');
+				@await writeLine('RCPT to: ${user.address}');
 				@await readLine(250);
 			}
 			@await writeLine('DATA');


### PR DESCRIPTION
This PR adds support for display names.
I first considered actually parsing the address, but then thought ... wait thats nonsense, as i would need to know the proper quotations and brackets and whatnot to use it. With split up fields to start with, it makes more sense to me. Let me know what you think. (And sorry about the whitespace noise, i have auto-trim or something enabled in my editor.)

Changes:
- Replaced simple string's with Address abstract
```haxe
mailer.send({
  ...
  from: {
    address: 'a@b.c',
    displayName: "It's me Mario!",
  }
  ...
});

but it still supports a single string

mailer.send({
  ...
  from: 'a@b.c',
  ...
});
```
- moved SmtpMailer.formatAddress() to new AddressTools class
- use display name in FROM and TO fields in MultipartEncoder
